### PR TITLE
修复生产模式下，产包的阴影样式（box-shadow）失效问题

### DIFF
--- a/src/views/cart/modules/Tabbar.vue
+++ b/src/views/cart/modules/Tabbar.vue
@@ -55,10 +55,16 @@ export default {
 }
 </script>
 
+<style>
+:root {
+  --submit-bar-shadow: 0px -2px 10px 0px rgba(0, 0, 0, 0.08);
+}
+</style>
+
 <style scoped>
 .submit-bar {
-  box-shadow: 0px -2px 10px 0px rgba(0, 0, 0, 0.08);
-
+  /* 这里使用 css 函数，是为了避免旧版本 vue-cli 依赖的 css 压缩工具（mini-css-extract-plugin）导致的 bug */
+  box-shadow: var(--submit-bar-shadow);
 }
 .van-submit-bar {
   bottom: 100px;

--- a/src/views/user/modules/Order.vue
+++ b/src/views/user/modules/Order.vue
@@ -66,6 +66,12 @@ export default {
 }
 </script>
 
+<style>
+:root {
+  --user-order-shadow: 0px 2px 16px 0px rgba(0, 0, 0, 0.09);
+}
+</style>
+
 <style lang="scss" scoped>
 @import "@/styles/variables.scss";
 
@@ -73,7 +79,7 @@ export default {
   width: 702px;
   height: 268px;
   margin: 0 auto;
-  box-shadow: 0px 2px 16px 0px rgba(0, 0, 0, 0.09);
+  box-shadow: var(--user-order-shadow); // 这里使用 css 函数，是为了避免旧版本 vue-cli 依赖的 css 压缩工具（mini-css-extract-plugin）导致的 bug
   border-radius: 24px;
   margin-top: 42px;
   .order__title {

--- a/src/views/user/modules/Tools.vue
+++ b/src/views/user/modules/Tools.vue
@@ -29,13 +29,19 @@ export default {
 }
 </script>
 
+<style>
+:root {
+  --user-tools-shadow: 0px 2px 16px 0px rgba(0, 0, 0, 0.09);
+}
+</style>
+
 <style lang="scss" scoped>
 .user-tools {
   width: 702px;
   background: rgba(255, 255, 255, 1);
   margin: 0 auto;
   margin-top: 24px;
-  box-shadow: 0px 2px 16px 0px rgba(0, 0, 0, 0.09);
+  box-shadow: var(--user-tools-shadow); // 这里使用 css 函数，是为了避免旧版本 vue-cli 依赖的 css 压缩工具（mini-css-extract-plugin）导致的 bug
   border-radius: 24px;
   overflow: hidden;
 }


### PR DESCRIPTION
产包阴影失效已修复。

项目里依赖的 `@vue/cli-service` 版本有点旧了，`@vue/cli-service` 又依赖了旧版本的 `mini-css-extract-plugin`，`mini-css-extract-plugin` 会在项目打产包的时候调用，压缩 css，最后又把正确的阴影样式压缩成了错误的阴影样式：

```css
.demo {
  box-shadow: 0px 2px 16px 0px rgba(0, 0, 0, 0.09); /* 1. 项目内的原样式，未经过编译的样式 */
  box-shadow: 0px min(0.267vw, 1.493px) min(2.133vw, 11.947px) 0px rgba(0, 0, 0, 0.09); /* 2. mobile-forever 编译过的样式 */
  box-shadow: 0 0 min(.267vw, 1.493px) min(2.133vw, 11.947px) rgba(0, 0, 0, .09); /* 3.1. 经过旧版本的 `mini-css-extract-plugin` 压缩出来的错误的样式 */
  box-shadow: 0 min(.267vw, 1.493px) min(2.133vw, 11.947px) 0 rgba(0, 0, 0, .09); /* 3.2. 升级 `@vue/cli-service` 之后，压缩的正确的结果样式 */
}
```

mobile-forever 的编译结果没问题，主要是 css 压缩工具版本的问题，目前是用 css 函数规避了上面代码块注释 `3.1` 的错误，但是每个 `box-shadow` 都这么写就比较麻烦了，之后我看看能不能升个依赖，貌似有很多要改的。